### PR TITLE
dont use mediastream.stop

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,10 +335,6 @@ module.exports = State.extend({
     stop: function () {
         this.stopVolumeMonitor();
 
-        if (this.stream.stop) {
-            this.stream.stop();
-        }
-
         this.getTracks().forEach(function (track) {
             if (track.readyState !== 'ended') {
                 track.stop();


### PR DESCRIPTION
mostly to make chrome complain less. The removal would already be handled.
